### PR TITLE
ДЗ#3

### DIFF
--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+       maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html
+          name: html
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - "rm"
+                - "/usr/share/nginx/html/index.html"
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      initContainers:
+      - name: install
+        image: busybox:stable
+        command:
+        - wget
+        - "-O"
+        - "/init/index.html"
+        - http://github.com
+        volumeMounts:
+        - name: html
+          mountPath: "/init"
+      volumes:
+      - name: html
+        emptyDir:
+          sizeLimit: 10Mi

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /homepage
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-service
+            port:
+              number: 8000
+      - path: /(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: nginx-service
+            port:
+              number: 8000

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -3,21 +3,15 @@ kind: Ingress
 metadata:
   name: nginx-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
   - host: homework.otus
     http:
       paths:
-      - path: /homepage
-        pathType: Prefix
-        backend:
-          service:
-            name: nginx-service
-            port:
-              number: 8000
-      - path: /(.*)
-        pathType: ImplementationSpecific
+      - pathType: ImplementationSpecific
+        path: /index.html|homepage
         backend:
           service:
             name: nginx-service

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  ports:
+  - port: 8000
+    targetPort: 80
+  selector:
+    app: nginx


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [X] Основное ДЗ
 - [X] Задание со *

## В процессе сделано:
 - Доработан deployment.yaml с использованием readiness-пробы.
 - Создан манифест service.yaml, описывающий сервис
типа ClusterIP, который будет направлять трафик на поды.
 - Установлен ingress-контроллер nginx
 - Создан манифест ingress.yaml, в котором описан объект типа ingress, направляющий все http запросы к хосту homework.otus на ранее созданный сервис. В результате запрос http://homework.otus/index.html должен отдавать код html
страницы, находящейся в подах, а также rewrite-правила, чтобы обращение по адресу http://homework.otus/homepage
форвардилось на http://homework.otus/index.html

## Как запустить проект:
```
vyf@Vyf-Laptop ~/g/v/kubernetes-networks ❯❯❯ kubectl apply -f namespace.yaml
namespace/homework created
vyf@Vyf-Laptop ~/g/v/kubernetes-networks ❯❯❯ kubectl apply -f deployment.yaml -f service.yaml -f ingress.yaml -n homework                                 
deployment.apps/nginx created
service/nginx-service created
ingress.networking.k8s.io/nginx-ingress created
```

## Как проверить работоспособность:
Для проверки работоспособности необходимо сперва узнать ip адрес, после чего прописать его в hosts.
```
vyf@Vyf-Laptop ~/g/v/kubernetes-networks ❯❯❯ minikube ip
192.168.39.168
vyf@Vyf-Laptop ~/g/v/kubernetes-networks ❯❯❯ echo "192.168.39.168 homework.otus" | sudo tee -a /etc/hosts                                                
192.168.39.168 homework.otus
```
После чего можно отправить тестовые запросы:
```
vyf@Vyf-Laptop ~/g/v/kubernetes-networks ❯❯❯ curl http://homework.otus
vyf@Vyf-Laptop ~/g/v/kubernetes-networks ❯❯❯ curl http://homework.otus/index.html
vyf@Vyf-Laptop ~/g/v/kubernetes-networks ❯❯❯ curl http://homework.otus/homepage
```
В результате выполнения всех трех команд выдается корректный html файл, в других случаях ошибка 404
## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
